### PR TITLE
v1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ The format is based on [Keep a Changelog][keep-a-changelog]
 <!-- and this project adheres to [Semantic Versioning][semantic-versioning]. -->
 
 ## [Unreleased]
-- Nothing right now
+### New
+- Implemented query timeout in all clients
+- Implemented a short-quick-type quiers directly in ddns class
+- Added simple recursive server example
+
+### Changes
+- Changed internal naming of createNXDomainResponseFromRequest to createNotFoundResponseFromRequest in serverutils
+- Changed internal naming of rawQuery to Query in all clients
+- Updated examples and readme to support new short-quick-type queries
+
+### Fixes
+- Cleanup of lingering objects on errors or rejects in all clients
+
 
 ## [1.0.0] (2021-01-??)
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog][keep-a-changelog]
 <!-- and this project adheres to [Semantic Versioning][semantic-versioning]. -->
 
 ## [Unreleased]
+- Nothing
+
+## [1.0.1] (2021-01-02)
 ### New
 - Implemented query timeout in all clients
 - Implemented a short-quick-type quiers directly in ddns class
@@ -17,10 +20,10 @@ The format is based on [Keep a Changelog][keep-a-changelog]
 ### Fixes
 - Cleanup of lingering objects on errors or rejects in all clients
 
-
-## [1.0.0] (2021-01-??)
+## [1.0.0] (2021-01-01)
 - Initial release
 
 [keep-a-changelog]: http://keepachangelog.com/en/1.0.0/
 [Unreleased]: https://github.com/DSorlov/node-ddns/compare/master...dev
-[1.0.0]: https://github.com/DSorlov/eid-provider/releases/tag/v1.0.0
+[1.0.1]: https://github.com/DSorlov/node-ddns/releases/tag/v1.0.1
+[1.0.0]: https://github.com/DSorlov/node-ddns/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ will be found in `request.questions[0].name`.
 
 ### Examples
 ```
+npm run example-client-simple
 npm run example-client-udp
 npm run example-client-tcp
 npm run example-client-tls
@@ -86,4 +87,5 @@ npm run example-server-tcp
 npm run example-server-tls
 npm run example-server-doh
 npm run example-server-ddns
+npm run example-server-recursive
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # node-ddns 
 
 ![NPM version](https://img.shields.io/npm/v/node-ddns.svg?style=flat)
-![stability-stable](https://img.shields.io/badge/stability-development-red.svg)
+![stability-stable](https://img.shields.io/badge/stability-stable-green.svg)
 ![version](https://img.shields.io/badge/version-1.0.1-red.svg)
 ![maintained](https://img.shields.io/maintenance/yes/2021.svg)
 [![maintainer](https://img.shields.io/badge/maintainer-daniel%20sörlöv-blue.svg)](https://github.com/DSorlov)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![maintainer](https://img.shields.io/badge/maintainer-daniel%20sörlöv-blue.svg)](https://github.com/DSorlov)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://img.shields.io/github/license/DSorlov/node-ddns)
 
-> A DNS Client, Server and DDNS Implementation in Pure JavaScript, only dependant on [dns-packet](https://github.com/mafintosh/dns-packet) and [node-ip](https://github.com/indutny/node-ip).
+> A DNS Client, Server and DDNS Implementation in Pure JavaScript, only dependant on [dns-packet](https://github.com/mafintosh/dns-packet) and [node-ip](https://github.com/indutny/node-ip). Huge thanks to [dns2](https://github.com/song940/node-dns) for inspiration and lots of smart code.
 
 ### Features
 
@@ -28,23 +28,23 @@ npm install node-ddns
 
 ### Example Client
 
-Lookup the A-record for the domain `google.com`.
+Most simple lookup the A-record for the domain `google.com`.
 
 ```js
 const ddns = require('node-ddns');
-const server = "1.1.1.1";
+const dns = new ddns();
 
-ddns.UDPClient.rawQuery(server,[{type: 'A', name: 'google.com'}]).then((result)=>{
-    console.log(result);
-})
+dns.ResolveA('www.google.com').then((result)=>{
+    console.log(result.answers);
+}).catch((error)=>{
+    console.log(error);
+});
 ```
 
 ### Example Server
 
 ```js
-
 const ddns = require('../..');
-
 const server = new ddns.UDPServer({port:53});
 
 server.listen().then(()=>{

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![NPM version](https://img.shields.io/npm/v/node-ddns.svg?style=flat)
 ![stability-stable](https://img.shields.io/badge/stability-development-red.svg)
-![version](https://img.shields.io/badge/version-1.0.0-red.svg)
+![version](https://img.shields.io/badge/version-1.0.1-red.svg)
 ![maintained](https://img.shields.io/maintenance/yes/2021.svg)
 [![maintainer](https://img.shields.io/badge/maintainer-daniel%20sörlöv-blue.svg)](https://github.com/DSorlov)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://img.shields.io/github/license/DSorlov/node-ddns)

--- a/client/doh.js
+++ b/client/doh.js
@@ -5,8 +5,9 @@ function getRandomInt (min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min
 }
 
-function rawQuery(server,queries,flags=dnsPacket.RECURSION_DESIRED,port=443) {
+function Query(server,queries,flags=dnsPacket.RECURSION_DESIRED,port=443,timeout=2) {
     return new Promise((resolve, reject) => {
+        var timer=setTimeout(()=>{clearTimeout(timer);reject('timeout');}, (timeout*1000));
 
         var packet = {
             type: 'query',
@@ -29,11 +30,13 @@ function rawQuery(server,queries,flags=dnsPacket.RECURSION_DESIRED,port=443) {
 
         const request = https.request(options, (response) => {
             response.on('data', (d) => {
+                clearTimeout(timer);
                 resolve(dnsPacket.decode(d));
             })
         })
 
         request.on('error', (e) => {
+            clearTimeout(timer);
             reject(Error(e));
         })
 
@@ -44,5 +47,5 @@ function rawQuery(server,queries,flags=dnsPacket.RECURSION_DESIRED,port=443) {
 
 
 module.exports = {
-    rawQuery: rawQuery
+    Query
 }

--- a/client/udp.js
+++ b/client/udp.js
@@ -5,8 +5,9 @@ function getRandomInt (min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min
 }
 
-async function rawQuery(server,queries,flags=dnsPacket.RECURSION_DESIRED,port=53,ipv=4) {
+async function Query(server,queries,flags=dnsPacket.RECURSION_DESIRED,port=53,ipv=4,timeout=2) {
     return new Promise((resolve, reject) => {
+        var timer=setTimeout(()=>{socket.close();clearTimeout(timer);reject('timeout');}, (timeout*1000));
         const socket = dgram.createSocket('udp'+ipv)
         const buf = dnsPacket.encode({
             type: 'query',
@@ -17,10 +18,12 @@ async function rawQuery(server,queries,flags=dnsPacket.RECURSION_DESIRED,port=53
 
         socket.on('message', message => {
             socket.close();
+            clearTimeout(timer);
             resolve(dnsPacket.decode(message));
         });
         
         socket.on('error', e => {
+            clearTimeout(timer);
             reject(e);
         });
         
@@ -29,5 +32,5 @@ async function rawQuery(server,queries,flags=dnsPacket.RECURSION_DESIRED,port=53
 }
 
 module.exports = {
-    rawQuery: rawQuery
+    Query: Query
 }

--- a/examples/client/doh.js
+++ b/examples/client/doh.js
@@ -2,6 +2,6 @@
 const ddns = require('../..');
 const server = "dns.google";
 
-ddns.DOHClient.rawQuery(server,[{type: 'A', name: 'google.com', class:'IN'}]).then((result)=>{
+ddns.DOHClient.Query(server,[{type: 'A', name: 'google.com', class:'IN'}]).then((result)=>{
     console.log(result);
 })

--- a/examples/client/simple.js
+++ b/examples/client/simple.js
@@ -1,0 +1,8 @@
+const ddns = require('../..');
+const dns = new ddns();
+
+dns.ResolveA('www.google.com').then((result)=>{
+    console.log(result.answers);
+}).catch((error)=>{
+    console.log(error);
+});

--- a/examples/client/tcp.js
+++ b/examples/client/tcp.js
@@ -2,6 +2,6 @@
 const ddns = require('../..');
 const server = "8.8.8.8";
 
-ddns.TCPClient.rawQuery(server,[{type: 'A', name: 'google.com', class:'IN'}]).then((result)=>{
+ddns.TCPClient.Query(server,[{type: 'A', name: 'google.com', class:'IN'}]).then((result)=>{
     console.log(result);
 })

--- a/examples/client/tls.js
+++ b/examples/client/tls.js
@@ -2,6 +2,6 @@
 const ddns = require('../..');
 const server = "getdnsapi.net";
 
-ddns.TLSClient.rawQuery(server,[{type: 'A', name: 'google.com', class:'IN'}]).then((result)=>{
+ddns.TLSClient.Query(server,[{type: 'A', name: 'google.com', class:'IN'}]).then((result)=>{
     console.log(result);
 })

--- a/examples/client/udp.js
+++ b/examples/client/udp.js
@@ -2,6 +2,6 @@
 const ddns = require('../..');
 const server = "1.1.1.1";
 
-ddns.UDPClient.rawQuery(server,[{type: 'A', name: 'google.com', class:'IN'}]).then((result)=>{
+ddns.UDPClient.Query(server,[{type: 'A', name: 'google.com', class:'IN'}]).then((result)=>{
     console.log(result);
 })

--- a/examples/server/ddns.js
+++ b/examples/server/ddns.js
@@ -47,7 +47,7 @@ function handleRequest(request, response, rinfo) {
         var answers = ddns.ServerUtilities.objectZoneLookup(zoneData,question);
         if (answers.length==0) {
             console.log(`Query for ${question.type} records of '${question.name}': responded NXDOMAIN` )
-            response(ddns.ServerUtilities.createNXDomainResponseFromRequest(request));
+            response(ddns.ServerUtilities.createNotFoundResponseFromRequest(request));
         } else {
             console.log(`Query for ${question.type} records of '${question.name}': responded '${JSON.stringify(answers)}'` )
             response(ddns.ServerUtilities.createSuccessResponseFromRequest(request,answers));

--- a/examples/server/doh.js
+++ b/examples/server/doh.js
@@ -24,7 +24,7 @@ server.on('request', (request, response, rinfo) => {
         var answers = ddns.ServerUtilities.objectZoneLookup(zoneData,question);
         if (answers.length==0) {
             console.log(`Query for ${question.type} records of '${question.name}': responded NXDOMAIN` )
-            response(ddns.ServerUtilities.createNXDomainResponseFromRequest(request));
+            response(ddns.ServerUtilities.createNotFoundResponseFromRequest(request));
         } else {
             console.log(`Query for ${question.type} records of '${question.name}': responded '${JSON.stringify(answers[0].data)}'` )
             response(ddns.ServerUtilities.createSuccessResponseFromRequest(request,answers));

--- a/examples/server/tcp.js
+++ b/examples/server/tcp.js
@@ -21,7 +21,7 @@ server.on('request', (request, response, rinfo) => {
         var answers = ddns.ServerUtilities.objectZoneLookup(zoneData,question);
         if (answers.length==0) {
             console.log(`Query for ${question.type} records of '${question.name}': responded NXDOMAIN` )
-            response(ddns.ServerUtilities.createNXDomainResponseFromRequest(request));
+            response(ddns.ServerUtilities.createNotFoundResponseFromRequest(request));
         } else {
             console.log(`Query for ${question.type} records of '${question.name}': responded '${JSON.stringify(answers[0].data)}'` )
             response(ddns.ServerUtilities.createSuccessResponseFromRequest(request,answers));

--- a/examples/server/udp.js
+++ b/examples/server/udp.js
@@ -21,7 +21,7 @@ server.on('request', (request, response, rinfo) => {
         var answers = ddns.ServerUtilities.objectZoneLookup(zoneData,question);
         if (answers.length==0) {
             console.log(`Query for ${question.type} records of '${question.name}': responded NXDOMAIN` )
-            response(ddns.ServerUtilities.createNXDomainResponseFromRequest(request));
+            response(ddns.ServerUtilities.createNotFoundResponseFromRequest(request));
         } else {
             console.log(`Query for ${question.type} records of '${question.name}': responded '${JSON.stringify(answers[0].data)}'` )
             response(ddns.ServerUtilities.createSuccessResponseFromRequest(request,answers));

--- a/index.js
+++ b/index.js
@@ -1,24 +1,59 @@
 const { TCPClient, UDPClient, DOHClient, TLSClient } = require('./client');
 const { TCPServer, UDPServer, DOHServer, TLSServer, ServerUtilities } = require('./server');
 const { EventEmitter } = require('events');
+const dnsPacket = require('dns-packet');
 
 class DDNS extends EventEmitter {
   constructor(options) {
     super();
     Object.assign(this, {
+      client: UDPClient,
       port: 53,
-      retries: 3,
-      timeout: 3,
+      protocol: 4,
+      timeout: 1,
       nameServers: [
         '8.8.8.8',
-        '114.114.114.114',
+        '1.1.1.1'
       ],
       rootServers: [
         'a', 'b', 'c', 'd', 'e', 'f',
         'g', 'h', 'i', 'j', 'k', 'l', 'm'
       ].map(x => `${x}.root-servers.net`)
     }, options);
-  }
+  };
+
+  #query = function(name, type, cls) {
+    const { port, nameServers, client, protocol, timeout } = this;
+    return Promise.race(nameServers.map(address => {
+      return new Promise((resolve,reject) => {
+        client.Query(address,[{type: type, name: name, class:cls}],dnsPacket.RECURSION_DESIRED,port,protocol,timeout).then((result)=>{
+          resolve(result);
+        }).catch((error)=>{
+          reject("error: "+error);
+        })
+      });
+    }));
+  };
+
+  Resolve = function(name, type = 'ANY', cls = 'IN') {
+    return this.#query(name, type, cls);
+  };
+
+  ResolveA = function(name) {
+    return this.#query(name, 'A', 'IN');
+  };
+
+  ResolveAAAA = function(name) {
+    return this.#query(name, 'AAAA', 'IN');
+  };
+
+  ResolveMX = function(name) {
+    return this.#query(name, 'MX', 'IN');
+  };
+
+  ResolveCNAME = function(name) {
+    return this.#query(name, 'CNAME', 'IN');
+  };
 }
 
 DDNS.TCPClient = TCPClient;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ddns",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple ddns library for NodeJS",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,8 @@
     "example-server-tcp": "node examples/server/tcp.js",
     "example-server-tls": "node examples/server/tls.js",
     "example-server-doh": "node examples/server/doh.js",
-    "example-server-ddns": "node examples/server/ddns.js"
+    "example-server-ddns": "node examples/server/ddns.js",
+    "example-server-recursive": "node examples/server/ddns.js"
   },
   "keywords": [
     "dns"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "example-client-tcp": "node examples/client/tcp.js",
     "example-client-tls": "node examples/client/tls.js",
     "example-client-doh": "node examples/client/doh.js",
+    "example-client-simple": "node examples/client/simple.js",
     "example-server-udp": "node examples/server/udp.js",
     "example-server-tcp": "node examples/server/tcp.js",
     "example-server-tls": "node examples/server/tls.js",

--- a/server/serverutilities.js
+++ b/server/serverutilities.js
@@ -4,17 +4,17 @@ class ServerUtilities {
     constructor() {
     };
 
-    static createSuccessResponseFromRequest(request,answers) {
-      var response = {};
+    static createSuccessResponseFromRequest(request,answers,flags=dnsPacket.AUTHORITATIVE_ANSWER) {
+      const response = {};
       response.id = request.id;
       response.type = 'response';
-      response.flags = (response.flags || 0) | dnsPacket.AUTHORITATIVE_ANSWER;
+      response.flags = (response.flags || 0) | flags;
       response.answers =  answers;
       return response;
     };
       
-    static createNXDomainResponseFromRequest(request) {
-      var response = {};
+    static createNotFoundResponseFromRequest(request) {
+      const response = {};
       response.id = request.id;
       response.type = 'response';
       response.flags = 387;
@@ -65,21 +65,11 @@ class ServerUtilities {
                     if (query.type=="ANY"||query.type==searchResult.type)
                     {
                       var result = Object.assign({},searchResult, {zone: zoneLookup.zone});
-
                       if (redact) {
                         result.name = query.name;
-                        try {
-                          delete result.username;
-                        } catch (e)
-                        {}
-                        try {
-                          delete result.password;
-                        } catch (e)
-                        {}
-                        try {
-                          delete result.zone;
-                        } catch (e)
-                        {}
+                        if (result.username) delete result.username;
+                        if (result.password) delete result.password;
+                        if (result.zone) delete result.zone;
                       }
                       results.push(result);
                     }


### PR DESCRIPTION
 ### New
- Implemented query timeout in all clients
- Implemented a short-quick-type quiers directly in ddns class
- Added simple recursive server example

### Changes
- Changed internal naming of createNXDomainResponseFromRequest to createNotFoundResponseFromRequest in serverutils
- Changed internal naming of rawQuery to Query in all clients
- Updated examples and readme to support new short-quick-type queries

### Fixes
- Cleanup of lingering objects on errors or rejects in all clients